### PR TITLE
changed docs from `\` to `/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ featurebrowser:
 ## Usage
 Run the featurebrowser generator from the command line:
 ```
-php bin\featurebrowser generate
+php bin/featurebrowser generate
 ```
 
 ### Code Quality Scores


### PR DESCRIPTION
I think on windows it accepts both (from what I have heard), but `\` will definitely not work on *nix systems.
